### PR TITLE
Fix view mode component visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,33 +302,59 @@ document.addEventListener('DOMContentLoaded', function(){
   // ---------- UI Updaters ----------
   function setView(v){
     CURRENT_VIEW = v;
-    $('#btn-owner').classList.toggle('sel', v==='owner');
-    $('#btn-viewer').classList.toggle('sel', v==='viewer');
+    console.log('Setting view to:', v);
+    
+    // Update view toggle buttons
+    const btnOwner = $('#btn-owner');
+    const btnViewer = $('#btn-viewer');
+    if (btnOwner) btnOwner.classList.toggle('sel', v==='owner');
+    if (btnViewer) btnViewer.classList.toggle('sel', v==='viewer');
     
     // Update view-specific component visibility
+    const nextStepOwner = $('#nextStepCardOwner');
+    const nextStepViewer = $('#nextStepCardViewer');
+    const compatScore = $('#compatScoreWrap');
+    const availToggle = $('#availabilityToggle');
+    
     if (v === 'owner') {
       // Owner view: show owner controls, hide viewer status
-      $('#nextStepCardOwner').classList.remove('hidden');
-      $('#nextStepCardViewer').classList.add('hidden');
-      $('#compatScoreWrap').classList.remove('hidden');
-      $('#availabilityToggle').classList.remove('hidden');
+      if (nextStepOwner) nextStepOwner.classList.remove('hidden');
+      if (nextStepViewer) nextStepViewer.classList.add('hidden');
+      if (compatScore) compatScore.classList.remove('hidden');
+      if (availToggle) availToggle.classList.remove('hidden');
     } else {
       // Viewer view: hide owner controls, show viewer status, hide score area only
-      $('#nextStepCardOwner').classList.add('hidden');
-      $('#nextStepCardViewer').classList.remove('hidden');
-      $('#compatScoreWrap').classList.add('hidden');
-      $('#availabilityToggle').classList.add('hidden');
+      if (nextStepOwner) nextStepOwner.classList.add('hidden');
+      if (nextStepViewer) nextStepViewer.classList.remove('hidden');
+      if (compatScore) compatScore.classList.add('hidden');
+      if (availToggle) availToggle.classList.add('hidden');
     }
     
     // Update viewer status display
     updateViewerStatus();
-    $('#scenarioHint').querySelector('.hint').textContent = v==='owner' ? 'Owner console view' : 'Viewer experience';
+    
+    // Update scenario hint
+    const scenarioHint = $('#scenarioHint');
+    const hintSpan = scenarioHint ? scenarioHint.querySelector('.hint') : null;
+    if (hintSpan) hintSpan.textContent = v==='owner' ? 'Owner console view' : 'Viewer experience';
   }
   function setAvail(a){
     AVAIL = a;
-    document.querySelectorAll('#availabilityToggle .pill').forEach(b => b.classList.toggle('sel', b.dataset.state===a));
-    $('#availLabel').textContent = a==='away' ? 'Owner away' : 'Owner available';
-    $('#ownerBusyBadge').classList.toggle('hidden', a!=='away');
+    console.log('Setting availability to:', a);
+    
+    // Update availability buttons
+    document.querySelectorAll('#availabilityToggle button[data-state]').forEach(b => {
+      b.classList.toggle('sel', b.dataset.state===a);
+    });
+    
+    // Update availability label
+    const availLabel = $('#availLabel');
+    if (availLabel) availLabel.textContent = a==='away' ? 'Owner away' : 'Owner available';
+    
+    // Update away badge
+    const busyBadge = $('#ownerBusyBadge');
+    if (busyBadge) busyBadge.classList.toggle('hidden', a!=='away');
+    
     updateViewerStatus();
   }
   
@@ -353,23 +379,36 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   function setScore(n){
     SCORE = clamp(parseInt(n||0,10), 0, 100);
-    $('#scoreNum').textContent = SCORE;
-    $('#scoreFill').style.width = SCORE + '%';
-    $('#confText').textContent = SCORE >= 75 ? 'High' : SCORE >= 60 ? 'Medium' : 'Low';
+    const scoreNum = $('#scoreNum');
+    const scoreFill = $('#scoreFill');
+    const confText = $('#confText');
+    
+    if (scoreNum) scoreNum.textContent = SCORE;
+    if (scoreFill) scoreFill.style.width = SCORE + '%';
+    if (confText) confText.textContent = SCORE >= 75 ? 'High' : SCORE >= 60 ? 'Medium' : 'Low';
   }
   function setStep(n){
     STEP = clamp(parseInt(n||1,10), 1, 4);
-    $('#dot-submitted').classList.toggle('active', STEP >= 1);
-    $('#dot-viewed').classList.toggle('active',   STEP >= 2);
-    $('#dot-acted').classList.toggle('active',    STEP >= 3);
-    $('#dot-closed').classList.toggle('active',   STEP >= 4);
+    
+    const dotSubmitted = $('#dot-submitted');
+    const dotViewed = $('#dot-viewed');
+    const dotActed = $('#dot-acted');
+    const dotClosed = $('#dot-closed');
+    const phaseFill = $('#phaseFill');
+    
+    if (dotSubmitted) dotSubmitted.classList.toggle('active', STEP >= 1);
+    if (dotViewed) dotViewed.classList.toggle('active', STEP >= 2);
+    if (dotActed) dotActed.classList.toggle('active', STEP >= 3);
+    if (dotClosed) dotClosed.classList.toggle('active', STEP >= 4);
+    
     // Fill to the END of the completed phase: 1→25%, 2→50%, 3→75%, 4→100%
     const pct = (STEP/4) * 100;
-    $('#phaseFill').style.width = pct + '%';
+    if (phaseFill) phaseFill.style.width = pct + '%';
   }
 
   // ---------- Scenario presets (demo only) ----------
   function applyScenario(code){
+    console.log('Applying scenario:', code);
     switch(code){
       case 'D-away':       setAvail('away');      setStep(1); setScore(62); break;
       case 'C-available':  setAvail('available'); setStep(1); setScore(78); break;
@@ -377,28 +416,41 @@ document.addEventListener('DOMContentLoaded', function(){
       case 'A-accepted':   setAvail('available'); setStep(3); setScore(84); break;
     }
     const label = code.includes('away') ? 'Owner away' : 'Owner available';
-    $('#scenarioHint').innerHTML = `Scenario: <span class="hint">${code.split('-')[0]} preset</span> • <span class="hint">${label}</span>`;
+    const scenarioHint = $('#scenarioHint');
+    if (scenarioHint) {
+      scenarioHint.innerHTML = `Scenario: <span class="hint">${code.split('-')[0]} preset</span> • <span class="hint">${label}</span>`;
+    }
     updateViewerStatus(); // Sync viewer status when scenario changes
   }
 
   // ---------- Confirm modal ----------
-  const confirmModal = $('#confirmModal');
   function openConfirm(type){
+    console.log('Opening confirm modal for:', type);
     const map = {
-      accept: `<b>Accept &amp; Send Link</b><br/>We’ll generate a scheduling/join link and notify the viewer.`,
-      needs : `<b>Needs Info</b><br/>We’ll ask the viewer to clarify scope or provide materials.`,
-      nope  : `<b>Not a Fit</b><br/>Message to Viewer (shown verbatim after confirm):<br/><em>“Thanks for reaching out. This isn’t a fit right now, but wishing you success.”</em>`
+      accept: `<b>Accept &amp; Send Link</b><br/>We'll generate a scheduling/join link and notify the viewer.`,
+      needs : `<b>Needs Info</b><br/>We'll ask the viewer to clarify scope or provide materials.`,
+      nope  : `<b>Not a Fit</b><br/>Message to Viewer (shown verbatim after confirm):<br/><em>"Thanks for reaching out. This isn't a fit right now, but wishing you success."</em>`
     };
     PENDING_ACTION = type;
-    $('#confirmText').innerHTML = map[type] || '';
-    confirmModal.classList.remove('hidden');
-    confirmModal.classList.add('flex');
+    
+    const confirmText = $('#confirmText');
+    const confirmModal = $('#confirmModal');
+    
+    if (confirmText) confirmText.innerHTML = map[type] || '';
+    if (confirmModal) {
+      confirmModal.classList.remove('hidden');
+      confirmModal.classList.add('flex');
+    }
   }
   function closeConfirm(){
-    confirmModal.classList.add('hidden');
-    confirmModal.classList.remove('flex');
+    const confirmModal = $('#confirmModal');
+    if (confirmModal) {
+      confirmModal.classList.add('hidden');
+      confirmModal.classList.remove('flex');
+    }
   }
   function applyAction(){
+    console.log('Applying action:', PENDING_ACTION);
     closeConfirm();
     if (STEP < 3) setStep(3); else setStep(4);
     alert('Action applied: ' + PENDING_ACTION);
@@ -414,32 +466,92 @@ document.addEventListener('DOMContentLoaded', function(){
       const d = Math.floor(remain/86400000);
       const h = Math.floor((remain%86400000)/3600000);
       const m = Math.floor((remain%3600000)/60000);
-      $('#expiry').textContent = `Expires in ${d}d ${h}h ${m}m`;
+      const expiry = $('#expiry');
+      if (expiry) expiry.textContent = `Expires in ${d}d ${h}h ${m}m`;
       setTimeout(tick, 20000);
     }
     tick();
   })();
 
   // ---------- Wire basic controls ----------
-  $('#btn-owner').addEventListener('click', ()=> setView('owner'));
-  $('#btn-viewer').addEventListener('click', ()=> setView('viewer'));
-  // availability buttons
-  document.querySelectorAll('#availabilityToggle .pill').forEach(btn=>{
-    btn.addEventListener('click', ()=> setAvail(btn.dataset.state));
+  // Debug: Check if elements exist before adding listeners
+  console.log('Setting up event listeners...');
+  
+  const btnOwner = $('#btn-owner');
+  const btnViewer = $('#btn-viewer');
+  console.log('View buttons found:', !!btnOwner, !!btnViewer);
+  
+  if (btnOwner) btnOwner.addEventListener('click', ()=> {
+    console.log('Owner button clicked');
+    setView('owner');
   });
+  if (btnViewer) btnViewer.addEventListener('click', ()=> {
+    console.log('Viewer button clicked');
+    setView('viewer');
+  });
+  
+  // availability buttons
+  const availButtons = document.querySelectorAll('#availabilityToggle button[data-state]');
+  console.log('Availability buttons found:', availButtons.length);
+  availButtons.forEach(btn=>{
+    btn.addEventListener('click', ()=> {
+      console.log('Availability button clicked:', btn.dataset.state);
+      setAvail(btn.dataset.state);
+    });
+  });
+  
   // scenario
-  $('#scenarioPicker').addEventListener('change', e=> applyScenario(e.target.value));
+  const scenarioPicker = $('#scenarioPicker');
+  if (scenarioPicker) {
+    scenarioPicker.addEventListener('change', e=> {
+      console.log('Scenario changed:', e.target.value);
+      applyScenario(e.target.value);
+    });
+  }
+  
   // next-step actions
-  $('#btn-accept').addEventListener('click', ()=> openConfirm('accept'));
-  $('#btn-needs').addEventListener('click',  ()=> openConfirm('needs'));
-  $('#btn-nope').addEventListener('click',   ()=> openConfirm('nope'));
+  const btnAccept = $('#btn-accept');
+  const btnNeeds = $('#btn-needs');
+  const btnNope = $('#btn-nope');
+  console.log('Action buttons found:', !!btnAccept, !!btnNeeds, !!btnNope);
+  
+  if (btnAccept) btnAccept.addEventListener('click', ()=> {
+    console.log('Accept button clicked');
+    openConfirm('accept');
+  });
+  if (btnNeeds) btnNeeds.addEventListener('click', ()=> {
+    console.log('Needs info button clicked');
+    openConfirm('needs');
+  });
+  if (btnNope) btnNope.addEventListener('click', ()=> {
+    console.log('Not a fit button clicked');
+    openConfirm('nope');
+  });
+  
   // confirm modal buttons
-  $('#confirmApply').addEventListener('click', applyAction);
-  $('#confirmBack').addEventListener('click', closeConfirm);
-  $('#confirmClose').addEventListener('click', closeConfirm);
-  $('#confirmBackdrop').addEventListener('click', closeConfirm);
+  const confirmApply = $('#confirmApply');
+  const confirmBack = $('#confirmBack');
+  const confirmClose = $('#confirmClose');
+  const confirmBackdrop = $('#confirmBackdrop');
+  
+  if (confirmApply) confirmApply.addEventListener('click', applyAction);
+  if (confirmBack) confirmBack.addEventListener('click', closeConfirm);
+  if (confirmClose) confirmClose.addEventListener('click', closeConfirm);
+  if (confirmBackdrop) confirmBackdrop.addEventListener('click', closeConfirm);
 
   // ---------- Initial state ----------
+  console.log('Initializing state...');
+  
+  // Debug: Check critical elements exist
+  const criticalElements = [
+    'btn-owner', 'btn-viewer', 'nextStepCardOwner', 'nextStepCardViewer', 
+    'compatScoreWrap', 'availabilityToggle', 'viewerOwnerStatus'
+  ];
+  criticalElements.forEach(id => {
+    const el = $('#' + id);
+    console.log(`Element #${id}:`, !!el);
+  });
+  
   setView('owner'); setAvail('available'); setStep(1); setScore(78);
   updateViewerStatus(); // Ensure viewer status is initialized
 

--- a/index.html
+++ b/index.html
@@ -81,6 +81,9 @@
   .tour-step{font-size:.78rem;color:#9aa0d6;margin-top:6px}
   .tour-arrow{stroke:url(#tourGrad);stroke-width:2.2}
   .tour-arrow-head{fill:#a78bfa}
+  
+  /* View-specific visibility */
+  .hidden { display: none !important; }
 </style>
 </head>
 <body>
@@ -169,7 +172,7 @@
             <div class="card-title text-sm mb-1">Compatibility</div>
             <div class="small">Confidence: <span id="confText">High</span></div>
           </div>
-          <div class="text-right">
+          <div id="compatScoreWrap" class="text-right">
             <div class="small mb-1">Score</div>
             <div class="score-wrap">
               <div class="score-track"><div id="scoreFill" class="score-fill"></div></div>
@@ -189,8 +192,8 @@
     <!-- Right column -->
     <div class="space-y-6">
 
-      <!-- Next Step -->
-      <div id="nextStepCard" class="glass rounded-2xl p-4">
+      <!-- Next Step - Owner View -->
+      <div id="nextStepCardOwner" class="glass rounded-2xl p-4">
         <div class="card-title text-sm mb-2">Next step</div>
         <div class="space-y-3">
           <button class="btn-primary w-full rounded-xl py-3" id="btn-accept" type="button">Accept &amp; Send Link</button>
@@ -198,6 +201,15 @@
           <button class="btn w-full rounded-xl py-3" id="btn-nope"    type="button">Not a Fit</button>
         </div>
         <div class="small mt-3">Choose one action to keep this LinkUp fresh.</div>
+      </div>
+
+      <!-- Next Step - Viewer View -->
+      <div id="nextStepCardViewer" class="glass rounded-2xl p-4 hidden">
+        <div class="card-title text-sm mb-2">Status</div>
+        <div id="viewerOwnerStatus" class="chip rounded-xl p-3">
+          <div class="small mb-1">Owner status: <span id="viewerStatusText">Available</span></div>
+          <div class="text-sm opacity-90" id="viewerStatusDesc">Your request is being reviewed. You'll hear back soon!</div>
+        </div>
       </div>
 
     </div>
@@ -292,6 +304,24 @@ document.addEventListener('DOMContentLoaded', function(){
     CURRENT_VIEW = v;
     $('#btn-owner').classList.toggle('sel', v==='owner');
     $('#btn-viewer').classList.toggle('sel', v==='viewer');
+    
+    // Update view-specific component visibility
+    if (v === 'owner') {
+      // Owner view: show owner controls, hide viewer status
+      $('#nextStepCardOwner').classList.remove('hidden');
+      $('#nextStepCardViewer').classList.add('hidden');
+      $('#compatScoreWrap').classList.remove('hidden');
+      $('#availabilityToggle').classList.remove('hidden');
+    } else {
+      // Viewer view: hide owner controls, show viewer status, hide score area only
+      $('#nextStepCardOwner').classList.add('hidden');
+      $('#nextStepCardViewer').classList.remove('hidden');
+      $('#compatScoreWrap').classList.add('hidden');
+      $('#availabilityToggle').classList.add('hidden');
+    }
+    
+    // Update viewer status display
+    updateViewerStatus();
     $('#scenarioHint').querySelector('.hint').textContent = v==='owner' ? 'Owner console view' : 'Viewer experience';
   }
   function setAvail(a){
@@ -299,6 +329,27 @@ document.addEventListener('DOMContentLoaded', function(){
     document.querySelectorAll('#availabilityToggle .pill').forEach(b => b.classList.toggle('sel', b.dataset.state===a));
     $('#availLabel').textContent = a==='away' ? 'Owner away' : 'Owner available';
     $('#ownerBusyBadge').classList.toggle('hidden', a!=='away');
+    updateViewerStatus();
+  }
+  
+  function updateViewerStatus(){
+    const statusText = $('#viewerStatusText');
+    const statusDesc = $('#viewerStatusDesc');
+    const statusCard = $('#viewerOwnerStatus');
+    
+    if (statusText && statusDesc && statusCard) {
+      if (AVAIL === 'away') {
+        statusText.textContent = 'Away';
+        statusDesc.textContent = 'The owner is currently away. Please check back later.';
+        statusCard.style.background = 'rgba(239, 68, 68, 0.1)';
+        statusCard.style.borderColor = 'rgba(239, 68, 68, 0.2)';
+      } else {
+        statusText.textContent = 'Available';
+        statusDesc.textContent = 'Your request is being reviewed. You\'ll hear back soon!';
+        statusCard.style.background = 'rgba(34, 197, 94, 0.1)';
+        statusCard.style.borderColor = 'rgba(34, 197, 94, 0.2)';
+      }
+    }
   }
   function setScore(n){
     SCORE = clamp(parseInt(n||0,10), 0, 100);
@@ -327,6 +378,7 @@ document.addEventListener('DOMContentLoaded', function(){
     }
     const label = code.includes('away') ? 'Owner away' : 'Owner available';
     $('#scenarioHint').innerHTML = `Scenario: <span class="hint">${code.split('-')[0]} preset</span> • <span class="hint">${label}</span>`;
+    updateViewerStatus(); // Sync viewer status when scenario changes
   }
 
   // ---------- Confirm modal ----------
@@ -389,6 +441,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
   // ---------- Initial state ----------
   setView('owner'); setAvail('available'); setStep(1); setScore(78);
+  updateViewerStatus(); // Ensure viewer status is initialized
 
   // ---------- Guided Tour config ----------
   window.TourConfig = {
@@ -400,7 +453,7 @@ document.addEventListener('DOMContentLoaded', function(){
       { sel:'#profilesRow', title:'People', body:'Owner ↔ Viewer cards. Tap to see mini-profiles.', place:'top' },
       { sel:'#viewerRequest', title:'Viewer Request & 1-Liner', body:'The action they chose (e.g., Schedule a Call) and their one-sentence context in quotes.', place:'top' },
       { sel:'#compatibilityCard', title:'Compatibility', body:'AI score + reasons. Confidence reflects data quality.', place:'left' },
-      { sel:'#nextStepCard', title:'Next step', body:'Choose one: Accept & Send Link, Needs Info, or Not a Fit (preview message shown before confirming).', place:'left' },
+      { sel:'#nextStepCardOwner', title:'Next step', body:'Choose one: Accept & Send Link, Needs Info, or Not a Fit (preview message shown before confirming).', place:'left' },
       { sel:'#progressSection', title:'Timeline + expiry', body:'Labels and progress share one grid; the fill snaps to the end of each phase segment.', place:'top' },
       { sel:'#footerActions', title:'Quick actions', body:'Download vCard, add to calendar, or open the public LinkUp page.', place:'top' },
       { sel:null, finish:true, title:'All set', body:'That’s the Owner view. Try the Viewer tour to see the other side.' }
@@ -411,7 +464,7 @@ document.addEventListener('DOMContentLoaded', function(){
       { sel:'#viewerRequest', title:'Your request', body:'Your selected action and your 1-liner appear here.', place:'top' },
       { sel:'#compatibilityCard', title:'Compatibility snapshot', body:'Quick read on mutual fit. High score? Proceed. Low? Maybe pause—especially if owner is Away.', place:'left' },
       { sel:'#progressSection', title:'Status + deadline', body:'See where things stand and when the LinkUp expires.', place:'top' },
-      { sel:'#nextStepCard', title:'What happens next', body:'Owner chooses an action. You’ll get the link or message here.', place:'left' },
+      { sel:'#nextStepCardViewer', title:'What happens next', body:'Owner chooses an action. You\'ll get the link or message here.', place:'left' },
       { sel:'#footerActions', title:'Open public page', body:'Check details or share from the public LinkUp page.', place:'top' },
       { sel:null, finish:true, title:'That’s it', body:'Short, decisive, no thread fatigue. You’re done.' }
     ]


### PR DESCRIPTION
Fixes view synchronization in the LinkUp demo by correctly toggling visibility of view-specific components and availability status.

The previous implementation failed to hide the owner's "Next Step" card in viewer mode and incorrectly hid the entire compatibility card instead of just the score. This PR ensures that the correct cards and elements are displayed for each view (Owner/Viewer) and that availability status updates are reflected consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb2a39f2-7fb2-4c58-acd6-3c83c3653f0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb2a39f2-7fb2-4c58-acd6-3c83c3653f0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

